### PR TITLE
feat(module-1): Implementing ride-cleansing and rides-and-fares

### DIFF
--- a/ride-cleansing/src/main/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingExercise.java
+++ b/ride-cleansing/src/main/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingExercise.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;
 import org.apache.flink.training.exercises.common.sources.TaxiRideGenerator;
 import org.apache.flink.training.exercises.common.utils.MissingSolutionException;
+import org.apache.flink.training.exercises.common.utils.GeoUtils;
 
 /**
  * The Ride Cleansing exercise from the Flink training.
@@ -80,7 +81,12 @@ public class RideCleansingExercise {
     public static class NYCFilter implements FilterFunction<TaxiRide> {
         @Override
         public boolean filter(TaxiRide taxiRide) throws Exception {
-            throw new MissingSolutionException();
+            if (GeoUtils.isInNYC(taxiRide.startLon, taxiRide.startLat) &&
+                    GeoUtils.isInNYC(taxiRide.endLon, taxiRide.endLat)) {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
+++ b/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
@@ -19,6 +19,8 @@
 package org.apache.flink.training.exercises.ridesandfares;
 
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -99,19 +101,39 @@ public class RidesAndFaresExercise {
     public static class EnrichmentFunction
             extends RichCoFlatMapFunction<TaxiRide, TaxiFare, RideAndFare> {
 
+        private ValueState<TaxiRide> startState;
+        private ValueState<TaxiFare> fareState;
+
         @Override
         public void open(Configuration config) throws Exception {
-            throw new MissingSolutionException();
+            startState = getRuntimeContext().getState(new ValueStateDescriptor<>("startState", TaxiRide.class));
+            fareState = getRuntimeContext().getState(new ValueStateDescriptor<>("fareState", TaxiFare.class));
         }
 
         @Override
         public void flatMap1(TaxiRide ride, Collector<RideAndFare> out) throws Exception {
-            throw new MissingSolutionException();
+            TaxiFare taxiFare = fareState.value();
+
+            if (taxiFare == null) {
+                startState.update(ride);
+            }
+            else {
+                out.collect(new RideAndFare(ride, taxiFare));
+                fareState.clear();
+            }
         }
 
         @Override
         public void flatMap2(TaxiFare fare, Collector<RideAndFare> out) throws Exception {
-            throw new MissingSolutionException();
+            TaxiRide startRide = startState.value();
+
+            if (startRide != null) {
+                out.collect(new RideAndFare(startRide, fare));
+                startState.clear();
+            }
+            else {
+                fareState.update(fare);
+            }
         }
     }
 }

--- a/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
+++ b/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
@@ -101,8 +101,8 @@ public class RidesAndFaresExercise {
     public static class EnrichmentFunction
             extends RichCoFlatMapFunction<TaxiRide, TaxiFare, RideAndFare> {
 
-        private ValueState<TaxiRide> startState;
-        private ValueState<TaxiFare> fareState;
+        private transient ValueState<TaxiRide> startState;
+        private transient ValueState<TaxiFare> fareState;
 
         @Override
         public void open(Configuration config) throws Exception {


### PR DESCRIPTION
* Implemented ride-cleaning through filtering in only rides that started and finished within NYC range
* In rides-and-fares, TaxiRide and TaxiFare records may come in different order, so we need to have state for each
  * Whenever a pair is paired, clean the state that was set